### PR TITLE
Allow using NT4 over ADB

### DIFF
--- a/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
+++ b/unity/Assets/QuestNav/Network/NetworkTableConnection.cs
@@ -326,6 +326,7 @@ namespace QuestNav.Network
             {
                 generateIP(),
                 "172.22.11.2",
+                "127.0.0.1",
                 $"roboRIO-{teamNumber}-FRC.local",
                 $"roboRIO-{teamNumber}-FRC.lan",
                 $"roboRIO-{teamNumber}-FRC.frc-field.local"
@@ -333,14 +334,6 @@ namespace QuestNav.Network
 
             while (!connectionEstablished)
             {
-                // Check if the network is reachable.
-                if (Application.internetReachability == NetworkReachability.NotReachable)
-                {
-                    Log($"Network not reachable. Waiting {QuestNavConstants.Network.UNREACHABLE_NETWORK_DELAY} seconds before reattempting.", QueuedLogger.LogLevel.Warning);
-                    await Task.Delay(QuestNavConstants.Network.UNREACHABLE_NETWORK_DELAY * 1000);
-                    continue;
-                }
-
                 Log("Starting NT4 connection attempt cycle");
 
                 foreach (string candidate in candidateAddresses)

--- a/unity/Assets/QuestNav/UI/UIManager.cs
+++ b/unity/Assets/QuestNav/UI/UIManager.cs
@@ -161,7 +161,14 @@ namespace QuestNav.UI
                 {
                     myAddressLocal = ip.ToString();
                     TextMeshProUGUI ipText = ipAddressText as TextMeshProUGUI;
-                    ipText.text = myAddressLocal;
+                    if (myAddressLocal == "127.0.0.1")
+                    {
+                        ipText.text = "USB";
+                    }
+                    else
+                    {
+                        ipText.text = myAddressLocal;
+                    }
                 }
                 break;
             }

--- a/unity/Assets/QuestNav/UI/UIManager.cs
+++ b/unity/Assets/QuestNav/UI/UIManager.cs
@@ -161,14 +161,7 @@ namespace QuestNav.UI
                 {
                     myAddressLocal = ip.ToString();
                     TextMeshProUGUI ipText = ipAddressText as TextMeshProUGUI;
-                    if (myAddressLocal == "127.0.0.1")
-                    {
-                        ipText.text = "No Adapter Found";
-                    }
-                    else
-                    {
-                        ipText.text = myAddressLocal;
-                    }
+                    ipText.text = myAddressLocal;
                 }
                 break;
             }


### PR DESCRIPTION
Using the command `adb reverse tcp:5810 tcp:5810` when ADB is connected on the RoboRIO will allow Network Tables to be accessible on the Quest at `127.0.0.1:5810`. Using this setup, only a USB cable connecting the Quest to the RoboRIO would be needed, instead of dealing with Ethernet.

This PR adds 127.0.0.1 as one of the addresses to check for the RoboRIO.