### PR TITLE
MitoCANdria

### DIFF
--- a/docs/docs/1-getting-started/6-wiring.md
+++ b/docs/docs/1-getting-started/6-wiring.md
@@ -98,9 +98,9 @@ Using a dedicated voltage regulator from your robot's main battery:
 
 Recommended USB-compliant 5V regulators:
 - [Redux Robotics Zinc-V](https://shop.reduxrobotics.com/zinc-v/)
+- [Grapple Robotics MitoCANdria](https://www.thethriftybot.com/products/mitocandria)
 
 Recommended 5V regulators (requires soldering and custom circuitry):
-- [Grapple Robotics MitoCANdria](https://www.thethriftybot.com/products/mitocandria)
 - [Pololu D36V50F5 Regulator](https://www.pololu.com/product/4091)
 
 :::tip


### PR DESCRIPTION
Just a small documentation suggestion to move the MitoCANdria to the USB-compliant section.

The MitoCANdria worked well for power our Quest 3S over USB. It doesn't require any more custom wiring than the Redux adapter. Just give it 12-volts and connect a USB output to the Quest adapter. Optionally, you can connect CAN to roboRIO for more functionality.